### PR TITLE
Expandable text block component

### DIFF
--- a/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.jsx
+++ b/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.jsx
@@ -19,7 +19,7 @@ const ExpandableTextBlock = ({
         less={
           <div className='expandable-text-block__button'>{showLessText}</div>
         }
-        className='expandable-text-block__body expandable-text-block__body-closed'
+        className='expandable-text-block__body expandable-text-block__body--closed'
       >
         <p className='expandable-text-block__body'>{body}</p>
         {footnote && (

--- a/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.jsx
+++ b/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.jsx
@@ -1,0 +1,33 @@
+import ShowMoreText from 'react-show-more-text'
+import './ExpandableTextBlock.scss'
+
+const ExpandableTextBlock = ({
+  body,
+  footnote,
+  showLessText = 'Show less',
+  showMoreText = 'Show more',
+  title
+}) => {
+  return (
+    <div className='expandable-text-block'>
+      {title && <h5 className='expandable-text-block__title'>{title}</h5>}
+      <ShowMoreText
+        lines={2}
+        more={
+          <div className='expandable-text-block__button'>{showMoreText}</div>
+        }
+        less={
+          <div className='expandable-text-block__button'>{showLessText}</div>
+        }
+        className='expandable-text-block__body expandable-text-block__body-closed'
+      >
+        <p className='expandable-text-block__body'>{body}</p>
+        {footnote && (
+          <p className='expandable-text-block__footnote'>{footnote}</p>
+        )}
+      </ShowMoreText>
+    </div>
+  )
+}
+
+export default ExpandableTextBlock

--- a/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.scss
+++ b/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.scss
@@ -10,7 +10,7 @@
     line-height: 2rem;
     margin: 1rem 0;
 
-    &-closed {
+    &--closed {
       margin-bottom: 0;
     }
   }

--- a/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.scss
+++ b/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.scss
@@ -1,0 +1,26 @@
+@import '../../styles/lumen-tokens';
+
+.expandable-text-block {
+  &__title {
+    @include typographylargeheadingh5;
+  }
+
+  &__body {
+    @include typographysmallparagraphbodycopy_regular;
+    line-height: 2rem;
+    margin: 1rem 0;
+
+    &-closed {
+      margin-bottom: 0;
+    }
+  }
+
+  &__footnote {
+    @include typographysmallparagraphxsmallcopy_italic;
+    margin-bottom: 1rem;
+  }
+
+  &__button {
+    margin-top: 1rem;
+  }
+}

--- a/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.stories.jsx
+++ b/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.stories.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import ExpandableTextBlock from './ExpandableTextBlock'
+
+export default {
+  title: 'Example/ExpandableTextBlock',
+  component: ExpandableTextBlock
+}
+
+const Template = (args) => <ExpandableTextBlock {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc massa nullam nunc ac vel justo scelerisque. Ipsum eget aliquam non adipiscing odio ornare in. Sed feugiat ultricies adipiscing nisl pellentesque elementum tortor massa sit. Tellus arcu facilisis turpis fermentum libero vulputate mauris amet sit. Ac tortor suspendisse aliquam volutpat dolor eget arcu. Sed quis vitae leo mi nisl id et. Sed interdum eget lacus interdum tincidunt duis orci enim.',
+  footnote: 'Lorem ipsum footnote',
+  title: 'Early childhood development'
+}

--- a/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.stories.jsx
+++ b/wvc-ourwork-nextjs/components/ExpandableTextBlock/ExpandableTextBlock.stories.jsx
@@ -15,3 +15,8 @@ Default.args = {
   footnote: 'Lorem ipsum footnote',
   title: 'Early childhood development'
 }
+
+export const BodyOnly = Template.bind({})
+BodyOnly.args = {
+  body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc massa nullam nunc ac vel justo scelerisque. Ipsum eget aliquam non adipiscing odio ornare in. Sed feugiat ultricies adipiscing nisl pellentesque elementum tortor massa sit. Tellus arcu facilisis turpis fermentum libero vulputate mauris amet sit. Ac tortor suspendisse aliquam volutpat dolor eget arcu. Sed quis vitae leo mi nisl id et. Sed interdum eget lacus interdum tincidunt duis orci enim.'
+}

--- a/wvc-ourwork-nextjs/package.json
+++ b/wvc-ourwork-nextjs/package.json
@@ -20,6 +20,7 @@
     "react-aria": "^3.20.0",
     "react-chartjs-2": "^4.3.1",
     "react-dom": "18.2.0",
+    "react-show-more-text": "^1.6.2",
     "react-stately": "^3.18.0",
     "sass": "^1.55.0",
     "sass-loader": "^13.1.0",

--- a/wvc-ourwork-nextjs/yarn.lock
+++ b/wvc-ourwork-nextjs/yarn.lock
@@ -928,6 +928,14 @@
     "@babel/helper-create-regexp-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
+"@babel/polyfill@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.12.1.tgz#1f2d6371d1261bbd961f3c5d5909150e12d0bd96"
+  integrity sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.4"
+
 "@babel/preset-env@^7.12.11":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.19.4.tgz#4c91ce2e1f994f717efb4237891c3ad2d808c94b"
@@ -5449,6 +5457,11 @@ core-js-pure@^3.23.3, core-js-pure@^3.25.1:
   version "3.26.0"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.0.tgz#7ad8a5dd7d910756f3124374b50026e23265ca9a"
   integrity sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==
+
+core-js@^2.6.5:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.0.4, core-js@^3.6.5, core-js@^3.8.2:
   version "3.26.0"
@@ -10008,6 +10021,14 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-show-more-text@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/react-show-more-text/-/react-show-more-text-1.6.2.tgz#46821c0ccf5fe5e3a28932bb857393a75607f499"
+  integrity sha512-Z6tRcnEosHvo07vZw36LxCjqYq4ghgaDI273b5XcayJ1PYbT56OKbaQlPqH7W9LGF5rhUVIhEDBPURuG5eO/Uw==
+  dependencies:
+    "@babel/polyfill" "^7.12.1"
+    prop-types "^15.7.2"
 
 react-sizeme@^3.0.1:
   version "3.0.2"


### PR DESCRIPTION
# Description

This PR adds the expandable text block component. I've used [this library](https://github.com/devzonetech/react-show-more-text) to implement the hide/show functionality needed for this component. This one is pretty simple in that it always accepts body text and can optionally take a title and footnote text. I've also set it up to accept the button text as a prop to allow for localization.

Fixes: https://www.notion.so/rangle/707082272d2b42609574ac475f44a1ec?v=857b05b5885c452a9c848bde0c6a6894&p=4e349b33f59b41c381f994b270d7af03&pm=s

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project at all breakpoints
- [x] This matches all the required acceptance criteria
- [x] This code has been tested in Chrome, Firefox & Safari
