### PR TITLE
Implement initial Impact Highlight Grid

### DIFF
--- a/wvc-ourwork-nextjs/components/ImpactHighlightGrid/ImpactHighlightGrid.jsx
+++ b/wvc-ourwork-nextjs/components/ImpactHighlightGrid/ImpactHighlightGrid.jsx
@@ -26,7 +26,7 @@ const ImpactHighlightGrid = ({ impactHighlights }) => {
   return (
     <div className='impact-highlight-grid'>
       {impactHighlights.map((item) => {
-        return <ImpactHighlight {...item} />
+        return <ImpactHighlight {...item} key={item.highlight} />
       })}
     </div>
   )

--- a/wvc-ourwork-nextjs/components/ImpactHighlightGrid/ImpactHighlightGrid.jsx
+++ b/wvc-ourwork-nextjs/components/ImpactHighlightGrid/ImpactHighlightGrid.jsx
@@ -1,0 +1,35 @@
+import './ImpactHighlightGrid.scss'
+
+export const ImpactHighlight = ({
+  firstLabel,
+  highlight,
+  secondLabel,
+  title,
+  year
+}) => {
+  return (
+    <div className='impact-highlight'>
+      <div className='impact-highlight__content'>
+        <h6 className='impact-highlight__title'>{title}</h6>
+        {firstLabel && <p className='impact-highlight__label'>{firstLabel}</p>}
+        <span className='impact-highlight__highlight'>{highlight}</span>
+        {secondLabel && (
+          <p className='impact-highlight__label'>{secondLabel}</p>
+        )}
+        <span className='impact-highlight__year'>{year}</span>
+      </div>
+    </div>
+  )
+}
+
+const ImpactHighlightGrid = ({ impactHighlights }) => {
+  return (
+    <div className='impact-highlight-grid'>
+      {impactHighlights.map((item) => {
+        return <ImpactHighlight {...item} />
+      })}
+    </div>
+  )
+}
+
+export default ImpactHighlightGrid

--- a/wvc-ourwork-nextjs/components/ImpactHighlightGrid/ImpactHighlightGrid.scss
+++ b/wvc-ourwork-nextjs/components/ImpactHighlightGrid/ImpactHighlightGrid.scss
@@ -1,0 +1,59 @@
+@import '../../styles/lumen-tokens';
+
+.impact-highlight-grid {
+  @media (min-width: 1024px) {
+    display: flex;
+    gap: 9.5rem;
+    justify-content: center;
+  }
+}
+
+.impact-highlight {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 37.5rem; // 600px;
+  text-align: center;
+
+  &:not(:only-child) {
+    margin-bottom: 4rem;
+  }
+
+  @media (min-width: 1024px) {
+    margin-left: 0;
+    margin-right: 0;
+
+    &:not(:only-child) {
+      margin-bottom: 0;
+    }
+  }
+
+  &__title {
+    @include typographysmallheadingh6;
+    color: $grey;
+    font-weight: 400;
+    margin-bottom: $space-m;
+    text-transform: uppercase;
+  }
+
+  &__year {
+    @include typographylargeparagraphbodycopy_regular;
+    color: $grey;
+    text-transform: uppercase;
+  }
+
+  &__highlight {
+    color: $orange;
+    display: block;
+    font-family: Lato;
+    font-size: 62px;
+    font-weight: 800;
+    line-height: 0.78;
+    margin-bottom: $space-m;
+  }
+
+  &__label {
+    @include typographylargeheadingh5;
+    color: $black;
+    margin-bottom: $space-m;
+  }
+}

--- a/wvc-ourwork-nextjs/components/ImpactHighlightGrid/ImpactHighlightGrid.stories.jsx
+++ b/wvc-ourwork-nextjs/components/ImpactHighlightGrid/ImpactHighlightGrid.stories.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import ImpactHighlightGrid, { ImpactHighlight } from './ImpactHighlightGrid'
+
+export default {
+  title: 'Example/ImpactHighlightGrid',
+  parameters: {
+    layout: 'fullscreen'
+  },
+  component: ImpactHighlightGrid
+}
+
+const Template = (args) => (
+  <div style={{ backgroundColor: '#FFFBF4', padding: '16px' }}>
+    <ImpactHighlightGrid {...args} />
+  </div>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  impactHighlights: [
+    {
+      title: 'Impact',
+      firstLabel: '',
+      secondLabel: 'deaths were prevented through the ENRICH program ',
+      highlight: '1,024',
+      year: '2016-2021'
+    },
+    {
+      title: 'Change',
+      firstLabel:
+        'In Ethiopia, women holding leadership positions on health committees increased from',
+      secondLabel: '',
+      highlight: '15% to 56%',
+      year: '2016-2021'
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Impact highlight items have a max-width of 600px per Josh.

Both labels/body sections are optional. I have included two Impact Highlights with different label configurations to show the difference.

We may need to make some CSS adjustments once this is in a template.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ x ] My code follows the style guidelines of this project at all breakpoints
- [ x ] This matches all the required acceptance criteria
- [ ] This code has been tested in Chrome, Firefox & Safari
