### PR TITLE
Fix/rangle/carousel

### DIFF
--- a/wvc-ourwork-nextjs/components/Carousel/Carousel.jsx
+++ b/wvc-ourwork-nextjs/components/Carousel/Carousel.jsx
@@ -11,7 +11,7 @@ const Carousel = ({ cards, title }) => {
   const [activeSlideNumber, setActiveSlideNumber] = useState(1)
 
   return (
-    <div className='carousel'>
+    <div id={`carousel-${title}`} className='carousel'>
       <div className='carousel--header'>
         {title && <h2>{title}</h2>}
         <div className='carousel-nav-container-desktop'>
@@ -35,11 +35,12 @@ const Carousel = ({ cards, title }) => {
         </div>
       </div>
       <Swiper
+        id={`swiper-${title}`}
         modules={[Navigation, A11y]}
         allowTouchMove={false}
         navigation={{
-          prevEl: '.carousel-nav-button-previous',
-          nextEl: '.carousel-nav-button-next'
+          prevEl: `#carousel-${title} .carousel-nav-button-previous`,
+          nextEl: `#carousel-${title} .carousel-nav-button-next`
         }}
         slidesPerView={'auto'}
         onSlideChange={(swiper) => {

--- a/wvc-ourwork-nextjs/components/EmergencyAlert/EmergencyAlert.jsx
+++ b/wvc-ourwork-nextjs/components/EmergencyAlert/EmergencyAlert.jsx
@@ -7,14 +7,14 @@ const EmergencyAlert = ({ body, buttonLabel, url, title }) => {
 
   return (
     showAlert && (
-      <div class='emergency-alert'>
-        <div class='emergency-alert__content-container'>
-          <div class='emergency-alert__icon-container'>
+      <div className='emergency-alert'>
+        <div className='emergency-alert__content-container'>
+          <div className='emergency-alert__icon-container'>
             <ExclamationMark />
           </div>
           <div>
-            <h4 class='emergency-alert__title'>{title}</h4>
-            <p class='emergency-alert__body'>
+            <h4 className='emergency-alert__title'>{title}</h4>
+            <p className='emergency-alert__body'>
               {body}
               {url && (
                 <a target='_blank' className='emergency-alert__link' href={url}>
@@ -26,7 +26,7 @@ const EmergencyAlert = ({ body, buttonLabel, url, title }) => {
         </div>
         <button
           aria-label='Close alert'
-          class='emergency-alert__button'
+          className='emergency-alert__button'
           onClick={() => setShowAlert(false)}
         >
           {buttonLabel}


### PR DESCRIPTION
# Description

Give carousel a unique ID so that prev/next navigation does not control all instances of a carousel on the page.

To test this, go to the Storybook Carousel component, to the Docs page. You’ll see two carousels on the page — one for program cards, one for statistic cards. Swiping on one of them does not provoke the other carousel to change. They are independent of each other.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ ] My code follows the style guidelines of this project at all breakpoints
- [ ] This matches all the required acceptance criteria
- [ ] This code has been tested in Chrome, Firefox & Safari
