### PR TITLE
fix: Disable map zoom and pan

### DIFF
--- a/components/MapChart/MapChartCountry/MapChartCountry.jsx
+++ b/components/MapChart/MapChartCountry/MapChartCountry.jsx
@@ -53,6 +53,7 @@ const MapChartCountries = ({
   padding = 200,
   markerCoordinates = [],
   onCountryDataLoaded = (evt) => {},
+  mapOptions = {},
   ...props
 }) => {
   const mapRef = useRef()
@@ -90,6 +91,7 @@ const MapChartCountries = ({
       id='countryMap'
       onLoad={() => setIsMapLoaded(true)}
       ref={mapRef}
+      {...mapOptions}
     >
       {mapMarkers}
       {popupInfo && (

--- a/components/MapChart/MapChartHeader/MapChartHeader.jsx
+++ b/components/MapChart/MapChartHeader/MapChartHeader.jsx
@@ -56,6 +56,7 @@ function MapChartHeader({
   countryDropdownLabel,
   programDropdownLabel,
   yearDropdownLabel,
+  mapOptions,
   children,
   ...props
 }) {
@@ -77,6 +78,7 @@ function MapChartHeader({
           countryCode={COUNTRY_NAMES[selectedCountry] || 'All'}
           onCountryDataLoaded={onCountryDataLoaded}
           markerCoordinates={showMarkers ? markerCoordinates : []}
+          mapOptions={mapOptions}
         >
           {children}
         </MapChartCountries>

--- a/components/MapChart/MapChartHeader/MapHeaderContainer.jsx
+++ b/components/MapChart/MapChartHeader/MapHeaderContainer.jsx
@@ -87,6 +87,17 @@ const getMarkerCoordinates = (
     })
 }
 
+const MAP_OPTIONS = {
+  boxZoom: false,
+  doubleClickZoom: false,
+  dragRotate: false,
+  dragPan: false,
+  keyboard: false,
+  scrollZoom: false,
+  touchPitch: false,
+  touchZoomRotate: false
+}
+
 //FIXME: storybook of this component is broken
 const MapHeaderContainer = ({
   showEmptyPrograms = false,
@@ -164,6 +175,7 @@ const MapHeaderContainer = ({
         onSelectedProgramTypeChange={setSelectedProgramType}
         programOptions={programOptions}
         mapStatistics={mapStatistics}
+        mapOptions={MAP_OPTIONS}
       />
     </>
   )


### PR DESCRIPTION
# Description

I was not able to reproduce this behavior anymore, but it was reported that zooming and panning the map would sometimes cause weird jumping behavior.

Simply disabling all the scrolling and panning from a simple object means we toggle map features on and off based on the current state of testing. If during testing no issues are found with a certain feature we can always turn it back on, if there are issues we now have a simple way to turn it off.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
