### PR TITLE
fix: year dropdown only shows years

### DIFF
--- a/components/MapChart/MapChartHeader/MapChartHeader.module.scss
+++ b/components/MapChart/MapChartHeader/MapChartHeader.module.scss
@@ -7,7 +7,7 @@
 .map-container {
   position: relative;
   display: block;
-  height: calc(100vh - 117px);
+  height: 70vh;
 }
 
 .map-header-container {
@@ -16,12 +16,10 @@
   &__map-legend {
     position: absolute;
     display: flex;
-    height: 15.5rem;
-    width: 18.063;
     background: $grey;
     flex-direction: column;
 
-    bottom: 0px;
+    bottom: 0;
     padding: $size-m;
 
     span {

--- a/components/MapChart/MapChartHeader/MapHeaderContainer.jsx
+++ b/components/MapChart/MapChartHeader/MapHeaderContainer.jsx
@@ -13,12 +13,20 @@ const PROGRAMMING_TYPE_FILL_COLOR = {
 }
 
 const getCountryOptions = (countryData, showEmptyPrograms, selectedYear) => {
+  const filtered = countryData.filter((country) => {
+    console.log(selectedYear)
+    return (
+      showEmptyPrograms ||
+      (showEmptyPrograms === false && country?.programs?.length > 0) ||
+      selectedYear === country['YEAR']
+    )
+  })
+  console.log(filtered)
   const data = countryData
     .filter(
       (country) =>
         showEmptyPrograms ||
         (showEmptyPrograms === false && country?.programs?.length > 0) ||
-        selectedYear === 'All' ||
         selectedYear === country['YEAR']
     )
     .reduce(
@@ -38,7 +46,6 @@ const getProgramOptions = (programData, selectedCountry, selectedYear) => {
       (n) =>
         n.country === countryName ||
         selectedCountry === 'All' ||
-        selectedYear === 'All' ||
         selectedYear === n['YEAR']
     )
     .reduce(
@@ -51,14 +58,12 @@ const getProgramOptions = (programData, selectedCountry, selectedYear) => {
     )
 }
 
-//TODO The design only shows 2021 but its risky to rely only on that number because
-// it will either never update, unless a code change is done, or the results might become weird
-// for now hardcoding 'all' and '2021' as the year is not even visible in the DB yet
 const getYearOptions = (programData) => {
   const years = programData
     .map((program) => program['YEAR'])
     .filter((year) => year !== undefined)
-  const uniqueYears = [...new Set(['All', '2021', ...years])]
+    .sort((a, b) => b - a)
+  const uniqueYears = [...new Set([...years])]
   return uniqueYears.map((year) => ({ value: year, label: year }))
 }
 
@@ -96,7 +101,7 @@ const MapHeaderContainer = ({
   countryData = [],
   ...props
 }) => {
-  const [selectedYear, setSelectedYear] = useState('All')
+  const [selectedYear, setSelectedYear] = useState('2021')
   const [selectedCountry, setSelectedCountry] = useState('All')
   const [selectedProgramType, setSelectedProgramType] = useState('All')
 


### PR DESCRIPTION
The year dropdown should not have any "all" filter. It should by default select the most current year and all other years after that.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ ] My code follows the style guidelines of this project at all breakpoints
- [ ] This matches all the required acceptance criteria
- [ ] This code has been tested in Chrome, Firefox & Safari
