### PR TITLE
fix: display map markers on country pages

### DIFF
--- a/components/HeroBlock/HeroBlock.jsx
+++ b/components/HeroBlock/HeroBlock.jsx
@@ -42,7 +42,7 @@ const HeroBlock = ({
     } else if (page === 'program') {
       setImgSrc('/HeroProgram.png')
     }
-  }, [[page]])
+  }, [page])
 
   return (
     <div className={styles['hero-block']}>
@@ -61,6 +61,7 @@ const HeroBlock = ({
                 countryCode={countryCode}
                 zoomLevel={mapZoomLevel}
                 interactive={false}
+                markerCoordinates={markerCoordinates}
               />
             </div>
           )}
@@ -76,21 +77,26 @@ const HeroBlock = ({
           )}
         </div>
         <div
-          className={`${styles['hero-block__main-content']} ${styles[`hero-block__main-content--${page}`]}`}
+          className={`${styles['hero-block__main-content']} ${
+            styles[`hero-block__main-content--${page}`]
+          }`}
         >
           <img src={imgSrc} alt='' aria-hidden />
           <div className={styles['hero-block__hero-content']}>
             <h1 className={styles['hero-block__title']}>{title}</h1>
             {body && <p className={styles['hero-block__body']}>{body}</p>}
-            <div className={styles['hero-block__cta']}><Button label={ctaLabel} url={ctaUrl} /></div>
+            <div className={styles['hero-block__cta']}>
+              <Button label={ctaLabel} url={ctaUrl} />
+            </div>
           </div>
         </div>
       </div>
-      {
-        highlights.length > 0 &&
+      {highlights.length > 0 && (
         <div className={styles['hero-block__summary-container']}>
           <div
-            className={`${styles['hero-block__summary-block']} ${styles[`hero-block__summary-block--${page}`]}`}
+            className={`${styles['hero-block__summary-block']} ${
+              styles[`hero-block__summary-block--${page}`]
+            }`}
           >
             <SummaryBlock
               highlights={highlights}
@@ -98,10 +104,11 @@ const HeroBlock = ({
               direction={summaryDirection}
             />
           </div>
-          <div className={styles['hero-block__children-container']}>{children}</div>
+          <div className={styles['hero-block__children-container']}>
+            {children}
+          </div>
         </div>
-      }
-      
+      )}
     </div>
   )
 }

--- a/components/MapChart/MapChartCountry/MapChartCountry.jsx
+++ b/components/MapChart/MapChartCountry/MapChartCountry.jsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { Source, Layer, Popup } from 'react-map-gl'
 import bbox from '@turf/bbox'
 import { multiPoint } from '@turf/helpers'
+import '../../../node_modules/mapbox-gl/dist/mapbox-gl.css'
 
 import MapChart from '../MapChart'
 import { useFetchGeoJson, useFitBounds, useMapMarkers } from '../mapHooks'

--- a/components/MapChart/MapChartHeader/MapChartHeader.jsx
+++ b/components/MapChart/MapChartHeader/MapChartHeader.jsx
@@ -98,13 +98,12 @@ const getCountryOptions = (countryData, showEmptyPrograms, selectedYear) => {
 
 const getProgramOptions = (programData, selectedCountry, selectedYear) => {
   return programData
-    ?.filter(
-      (n) => {
-        return n.COUNTRYCODE === selectedCountry ||
-        selectedCountry === 'All' ||
+    ?.filter((n) => {
+      return (
+        (n.COUNTRYCODE === selectedCountry || selectedCountry === 'All') &&
         selectedYear === n['YEAR']
-      }
-    )
+      )
+    })
     .reduce(
       (acc, { PROGRAM_TYPE }) => {
         return acc.find((n) => n.value === PROGRAM_TYPE) !== undefined

--- a/components/MapChart/MapChartHeader/MapChartHeader.jsx
+++ b/components/MapChart/MapChartHeader/MapChartHeader.jsx
@@ -129,9 +129,11 @@ const getYearOptions = (programData) => {
 // for simplicity, but it feels like there is more work to be done here
 const getMarkerColor = (programType) => {
   const PROGRAM_TYPE_FILL_COLOR = {
-    'Community Development': '#46BB95', //$green
-    'Chronic Emergencies & Fragile Contexts': '#FFBF00',
-    'Crisis Response': '#d00'
+    'sub-prog-CEFC': '#E7600C',
+    'sub-prog-SHIP': '#46BB95',
+    'sub-prog-MCD': '#9054A1',
+    'sub-prog-CR': '#006661',
+    'sub-prog-LCD': '#FDD25F'
   }
   return PROGRAM_TYPE_FILL_COLOR[programType]
 }
@@ -155,7 +157,7 @@ const getMarkerCoordinates = (
         mapData['CENTRAL_LAT'],
         {
           ...mapData,
-          fill: getMarkerColor(mapData['PROGRAM_TYPE'])
+          fill: getMarkerColor(mapData.SUB_PROGRAMMING_TYPE_CODE)
         }
       ]
     })


### PR DESCRIPTION
# Description
The markers would never properly render on the country template, even though they should and the code was almost identical as the main page. The main difference between the two was that "Home" was using `MapChartHeader` while "Country" is directly using `MapChartCountry`.

After a lot of debugging and banging my head I realised that in 7955c3587bda0 I fixed a similar issue for the main page map that was doing funky stuff. Solution there was to simply import the `mapbox-gl.css` file to ensure everything was working as expected.

This fix is really nothing more than passing the correct coordinates and then adding the CSS file...

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)