### PR TITLE
fix: timeline read more not showing

### DIFF
--- a/components/Timeline/Timeline.jsx
+++ b/components/Timeline/Timeline.jsx
@@ -10,15 +10,16 @@ export const Timeline = ({ data, isMobile }) => {
     <div className={styles['timeline-container']}>
       <Chrono
         mode={smallScreen ? 'VERTICAL' : 'HORIZONTAL'}
-        items={data.map((ea) => ({
-          ...ea,
-          cardSubtitle: ea.title
+        items={data.map((item) => ({
+          ...item,
+          cardSubtitle: item.title
         }))}
         showAllCardsHorizontal
         theme={{
           primary: '#E7600C'
         }}
         hideControls={smallScreen}
+        cardHeight={160}
       >
         <div className='chrono-icons'>
           {data.map((ea) => (


### PR DESCRIPTION
Some text would be cut-off from the timeline without showing the "show more" button. This is a bug in the actual component we are using.

By setting the `cardHeight` to 160 we resolve this particular problem. The problem with the cards mis-alligning for 2-3px is accepted by Josh

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ ] My code follows the style guidelines of this project at all breakpoints
- [ ] This matches all the required acceptance criteria
- [ ] This code has been tested in Chrome, Firefox & Safari
